### PR TITLE
Create lxqt-base-wm.particle

### DIFF
--- a/weekly/lxqt-base-wm.particle
+++ b/weekly/lxqt-base-wm.particle
@@ -1,0 +1,125 @@
+# Entropy Matter, Automated Entropy Packages Build Service, example spec file
+
+# List of packages required to be built.
+# Comma separated, example: app-foo/bar, bar-baz/foo
+# Mandatory, cannot be empty
+packages:
+    lxqt-base/lxqt-qtplugin,
+	  lxqt-base/lxqt-openssh-askpass,
+    lxqt-base/lxqt-notificationd,
+    lxqt-base/lxqt-runner,
+		lxqt-base/lxqt-policykit,
+		lxqt-base/lxqt-powermanagement,
+	  lxqt-base/lxqt-about,
+	  lxqt-base/lxqt-config,
+	  lxqt-base/lxqt-config-randr,
+    lxde-base/lxde-icon-theme,
+	  lxqt-base/lxqt-common,
+	  lxde-base/lxmenu-data,
+	  lxqt-base/lxqt-panel,
+	  lxqt-base/lxqt-session,
+
+
+# Enforce stable or unstable packages on emerge.
+# yes = only stable packages are accepted
+# no  = both stable and unstable packages are accepted
+# inherit = inherit portage make.conf.* settings for ACCEPT_KEYWORDS
+# Valid values are either "yes" or "no", "inherit"
+# Default is: inherit
+stable: inherit
+
+# Entropy repository where to commit packages
+# Mandatory, cannot be empty
+repository: sabayon-hell
+
+# Provide custom build arguments to Portage.
+# Default is: --verbose --nospinner
+build-args: --verbose --oneshot --nospinner --quiet-build=y --quiet-fail --fail-clean=y --complete-graph
+
+# Allow Source Package Manager (Portage) repository change?
+# Valid values are either "yes" or "no"
+# Default is: no
+spm-repository-change: no
+
+# In case of Source Package Manager repository change, allow
+# execution if the original repository does not contain
+# the package anymore?
+# Valid values are either "yes" or "no"
+# Default is: no
+spm-repository-change-if-upstreamed: yes
+
+# Allow compiling package even if it's not actually installed on system?
+# Valid values are either "yes" or "no"
+# Default is: no
+not-installed: no
+
+# Allow soft-blockers in the merge queue? Packages will be unmerged if yes.
+# Valid values are either "yes" or "no"
+# Default is: yes
+soft-blocker: yes
+
+# Allow package unmerges in the merge queue? Packages will be unmerged if yes.
+# Valid values are either "yes" or "no"
+# Default is: yes
+unmerge: yes
+
+# Allow dependencies to be pulled in?
+# Valid values are either "yes" or "no"
+# Default is: no
+dependencies: yes
+
+# Allow package downgrade?
+# Valid values are either "yes" or "no"
+# Default is: no
+downgrade: no
+
+# Allow package rebuild?
+# Valid values are either "yes" or "no"
+# Default is: no
+rebuild: no
+
+# Make possible to continue if one or more packages fail to build?
+# Valid values are either "yes" or "no"
+# Default is: no
+keep-going: yes
+
+# Allow new USE flags?
+# Valid values are either "yes" or "no"
+# Default is: no
+new-useflags: yes
+
+# Allow removed USE flags?
+# Valid values are either "yes" or "no"
+# Default is: no
+removed-useflags: yes
+
+# Package pre execution script hook
+# Valid value is path to executable file
+# Env vars:
+# MATTER_PACKAGE_NAMES       = space sep. list of names of the packages
+# that would be built. It does not reflect the name of the failing packages,
+# because they could be just dependencies of them.
+# pkgpre: /home/fabio/repos/entropy/services/matter_examples/pkgpre.sh
+
+# Package build post execution script hook, executed for each package
+# Valid value is path to executable file
+# Env vars:
+# MATTER_PACKAGE_NAMES       = space sep. list of names of the packages
+# that would be built. It does not reflect the name of the failing packages,
+# because they could be just dependencies of them.
+# pkgpost: /home/fabio/repos/entropy/services/matter_examples/pkgpost.sh
+
+# Env vars:
+# MATTER_PACKAGE_NAMES       = space sep. list of names of the packages
+# that would be built. It does not reflect the name of the failing packages,
+# because they could be just dependencies of them.
+# MATTER_PORTAGE_FAILED_PACKAGE_NAME = exact name (atom, CPV) of the failing
+# package, the one that triggered the buildfail hook.
+# MATTER_PORTAGE_REPOSITORY = Portage repository from where the package
+# comes from
+# MATTER_PORTAGE_BUILD_LOG_DIR = directory containing all the build logs of
+# the failed package
+buildfail: /particles/hooks/buildfail.sh
+
+# For more info regarding exported environment variables, please see:
+# matter --help

--- a/weekly/lxqt-base-wm.particle
+++ b/weekly/lxqt-base-wm.particle
@@ -4,20 +4,22 @@
 # Comma separated, example: app-foo/bar, bar-baz/foo
 # Mandatory, cannot be empty
 packages:
-    lxqt-base/lxqt-qtplugin,
+	  lxqt-base/libqtxdg,
+	  lxqt-base/lxqt-qtplugin,
 	  lxqt-base/lxqt-openssh-askpass,
-    lxqt-base/lxqt-notificationd,
-    lxqt-base/lxqt-runner,
-		lxqt-base/lxqt-policykit,
-		lxqt-base/lxqt-powermanagement,
+	  lxqt-base/lxqt-notificationd,
+	  lxqt-base/lxqt-runner,
+	  lxqt-base/lxqt-policykit,
+	  lxqt-base/lxqt-powermanagement,
 	  lxqt-base/lxqt-about,
 	  lxqt-base/lxqt-config,
 	  lxqt-base/lxqt-config-randr,
-    lxde-base/lxde-icon-theme,
+    	  lxde-base/lxde-icon-theme,
 	  lxqt-base/lxqt-common,
 	  lxde-base/lxmenu-data,
 	  lxqt-base/lxqt-panel,
 	  lxqt-base/lxqt-session,
+	  lxqt-base/lxqt-meta,
 
 
 # Enforce stable or unstable packages on emerge.


### PR DESCRIPTION
Layman -a qt
made a  lxqt particle for testing and 'cause it seemed fun to do.  
needs autoconf -13 or 9 
or just install newest from weekly..  autoconf cmake, openbox. 
Just rename lxqt-base-wm.particle >>>>   lxqt-base-wm.particle.workspace  
if any other fixes needed 
but my victim-vbox Sabayon works fine at the moment  
actual install will need to be debugged from nvidia update fail , i keep a few older kernels as fail-safe. 
tends to sometimes break updates.... so will test it on actual install soon as i fix driver.
lxqt-base/lxqt-panel compiled with +Everything.... 

